### PR TITLE
feat: render settle output with Rich

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies    = [
   "httpx>=0.28.1",
   "pandas>=3.0.1",
   "pydantic>=2.12.5",
+  "rich>=15.0.0",
   "typer>=0.25.1",
 ]
 

--- a/src/sharepay/cli.py
+++ b/src/sharepay/cli.py
@@ -73,6 +73,16 @@ def _transaction_amount(transaction: Transaction) -> Text:
     return Text(f"{transaction.amount:.2f} {transaction.currency}", style="bold")
 
 
+def _canonical_balances(group: ExpenseGroup) -> list[Balance]:
+    balances: dict[str, Balance] = {}
+    for balance in group.balances.values():
+        owner = group.alias.get(balance.owner, balance.owner).lower().strip()
+        if owner not in balances:
+            balances[owner] = Balance(owner=owner, currency=balance.currency)
+        balances[owner].value += balance.value
+    return list(balances.values())
+
+
 def _print_balances(console: Console, balances: list[Balance]) -> None:
     table = Table(title="Balances", box=box.ROUNDED)
     table.add_column("Member", style="bold")
@@ -150,7 +160,7 @@ def settle(
         msg = f"HTTP request failed: {exc}"
         raise typer.BadParameter(msg) from exc
     console = Console()
-    _print_balances(console, list(group.balances.values()))
+    _print_balances(console, _canonical_balances(group))
     _print_transactions(console, transactions)
 
 

--- a/src/sharepay/cli.py
+++ b/src/sharepay/cli.py
@@ -42,31 +42,31 @@ def _parse_aliases(alias_items: list[str] | None) -> dict[str, str]:
     return aliases
 
 
-def _normalized_balance_value(value: float, epsilon: float = 1e-6) -> float:
-    if abs(value) <= epsilon:
+def _display_balance_value(value: float) -> float:
+    rounded_value = round(value, 2)
+    if rounded_value == 0:
         return 0
-    return value
+    return rounded_value
 
 
-def _balance_style(value: float, epsilon: float = 1e-6) -> str:
-    if value > epsilon:
+def _balance_style(display_value: float) -> str:
+    if display_value > 0:
         return "red"
-    if value < -epsilon:
+    if display_value < 0:
         return "green"
     return "dim"
 
 
-def _balance_status(value: float, epsilon: float = 1e-6) -> Text:
-    if value > epsilon:
+def _balance_status(display_value: float) -> Text:
+    if display_value > 0:
         return Text("owes", style="red")
-    if value < -epsilon:
+    if display_value < 0:
         return Text("receives", style="green")
     return Text("settled", style="dim")
 
 
-def _balance_amount(balance: Balance) -> Text:
-    value = _normalized_balance_value(balance.value)
-    return Text(f"{value:+.2f} {balance.currency}", style=_balance_style(value))
+def _balance_amount(balance: Balance, display_value: float) -> Text:
+    return Text(f"{display_value:+.2f} {balance.currency}", style=_balance_style(display_value))
 
 
 def _transaction_amount(transaction: Transaction) -> Text:
@@ -80,7 +80,8 @@ def _print_balances(console: Console, balances: list[Balance]) -> None:
     table.add_column("Status")
 
     for balance in sorted(balances, key=lambda item: item.owner):
-        table.add_row(Text(balance.owner), _balance_amount(balance), _balance_status(balance.value))
+        display_value = _display_balance_value(balance.value)
+        table.add_row(Text(balance.owner), _balance_amount(balance, display_value), _balance_status(display_value))
 
     console.print(table)
 

--- a/src/sharepay/cli.py
+++ b/src/sharepay/cli.py
@@ -5,10 +5,16 @@ from typing import Annotated
 
 import httpx
 import typer
+from rich import box
+from rich.console import Console
+from rich.table import Table
+from rich.text import Text
 
+from .balance import Balance
 from .currency import Currency
 from .expense_group import DEFAULT_CURRENCY
 from .expense_group import ExpenseGroup
+from .transaction import Transaction
 from .utils import read_payment_csv
 
 app = typer.Typer(help="Calculate sharepay settlement transactions.")
@@ -34,6 +40,65 @@ def _parse_aliases(alias_items: list[str] | None) -> dict[str, str]:
             raise typer.BadParameter(msg)
         aliases[source] = target
     return aliases
+
+
+def _normalized_balance_value(value: float, epsilon: float = 1e-6) -> float:
+    if abs(value) <= epsilon:
+        return 0
+    return value
+
+
+def _balance_style(value: float, epsilon: float = 1e-6) -> str:
+    if value > epsilon:
+        return "red"
+    if value < -epsilon:
+        return "green"
+    return "dim"
+
+
+def _balance_status(value: float, epsilon: float = 1e-6) -> Text:
+    if value > epsilon:
+        return Text("owes", style="red")
+    if value < -epsilon:
+        return Text("receives", style="green")
+    return Text("settled", style="dim")
+
+
+def _balance_amount(balance: Balance) -> Text:
+    value = _normalized_balance_value(balance.value)
+    return Text(f"{value:+.2f} {balance.currency}", style=_balance_style(value))
+
+
+def _transaction_amount(transaction: Transaction) -> Text:
+    return Text(f"{transaction.amount:.2f} {transaction.currency}", style="bold")
+
+
+def _print_balances(console: Console, balances: list[Balance]) -> None:
+    table = Table(title="Balances", box=box.ROUNDED)
+    table.add_column("Member", style="bold")
+    table.add_column("Balance", justify="right")
+    table.add_column("Status")
+
+    for balance in sorted(balances, key=lambda item: item.owner):
+        table.add_row(Text(balance.owner), _balance_amount(balance), _balance_status(balance.value))
+
+    console.print(table)
+
+
+def _print_transactions(console: Console, transactions: list[Transaction]) -> None:
+    if not transactions:
+        console.print("[green]No transactions needed.[/green]")
+        return
+
+    table = Table(title="Settlement", box=box.ROUNDED)
+    table.add_column("From", style="bold red")
+    table.add_column("To", style="bold green")
+    table.add_column("Amount", justify="right")
+
+    for transaction in transactions:
+        table.add_row(Text(transaction.sender), Text(transaction.recipient), _transaction_amount(transaction))
+
+    console.print(table)
 
 
 @app.command()
@@ -83,12 +148,9 @@ def settle(
     except httpx.HTTPError as exc:
         msg = f"HTTP request failed: {exc}"
         raise typer.BadParameter(msg) from exc
-    if not transactions:
-        typer.echo("No transactions needed.")
-        return
-
-    for transaction in transactions:
-        typer.echo(str(transaction))
+    console = Console()
+    _print_balances(console, list(group.balances.values()))
+    _print_transactions(console, transactions)
 
 
 if __name__ == "__main__":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -27,6 +27,10 @@ def _assert_balance(output: str, member: str, amount: str, status: str) -> None:
     assert re.search(rf"│ {re.escape(member)}\s+│\s+{re.escape(amount)} │ {re.escape(status)}\s+│", output)
 
 
+def _assert_no_balance(output: str, member: str) -> None:
+    assert not re.search(rf"│ {re.escape(member)}\s+│", output)
+
+
 def _assert_settlement(output: str, sender: str, recipient: str, amount: str) -> None:
     assert "Balances" in output
     assert "Settlement" in output
@@ -133,6 +137,9 @@ def test_settle_alias_option(tmp_path: Path) -> None:
 
     assert result.exit_code == 0
     assert "Balances" in result.stdout
+    _assert_balance(result.stdout, "a", "+0.00 TWD", "settled")
+    _assert_balance(result.stdout, "b", "+0.00 TWD", "settled")
+    _assert_no_balance(result.stdout, "c")
     assert "No transactions needed." in result.stdout
 
 
@@ -145,6 +152,9 @@ def test_settle_alias_target_can_be_new_member(tmp_path: Path) -> None:
     result = runner.invoke(app, ["settle", "--file", str(csv_path), "--alias", "c=a"])
 
     assert result.exit_code == 0
+    _assert_balance(result.stdout, "a", "+50.00 TWD", "owes")
+    _assert_balance(result.stdout, "b", "-50.00 TWD", "receives")
+    _assert_no_balance(result.stdout, "c")
     _assert_settlement(result.stdout, "a", "b", "50.00 TWD")
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,4 @@
+import re
 from pathlib import Path
 
 import httpx
@@ -22,6 +23,16 @@ def _write_payments_csv(tmp_path: Path, content: str) -> Path:
     return csv_path
 
 
+def _assert_balance(output: str, member: str, amount: str, status: str) -> None:
+    assert re.search(rf"│ {re.escape(member)}\s+│\s+{re.escape(amount)} │ {re.escape(status)}\s+│", output)
+
+
+def _assert_settlement(output: str, sender: str, recipient: str, amount: str) -> None:
+    assert "Balances" in output
+    assert "Settlement" in output
+    assert re.search(rf"│ {re.escape(sender)}\s+│ {re.escape(recipient)}\s+│\s+{re.escape(amount)} │", output)
+
+
 def test_settle_csv_file(tmp_path: Path) -> None:
     csv_path = _write_payments_csv(
         tmp_path,
@@ -31,7 +42,10 @@ def test_settle_csv_file(tmp_path: Path) -> None:
     result = runner.invoke(app, ["settle", "--file", str(csv_path)])
 
     assert result.exit_code == 0
-    assert "c      -> a          200.00 TWD" in result.stdout
+    _assert_balance(result.stdout, "a", "-200.00 TWD", "receives")
+    _assert_balance(result.stdout, "b", "+0.00 TWD", "settled")
+    _assert_balance(result.stdout, "c", "+200.00 TWD", "owes")
+    _assert_settlement(result.stdout, "c", "a", "200.00 TWD")
 
 
 def test_settle_csv_file_uses_sheet_csv_parsing(tmp_path: Path) -> None:
@@ -43,7 +57,7 @@ def test_settle_csv_file_uses_sheet_csv_parsing(tmp_path: Path) -> None:
     result = runner.invoke(app, ["settle", "--file", str(csv_path)])
 
     assert result.exit_code == 0
-    assert "b      -> a          600.00 TWD" in result.stdout
+    _assert_settlement(result.stdout, "b", "a", "600.00 TWD")
 
 
 def test_settle_google_sheet(monkeypatch) -> None:
@@ -60,7 +74,7 @@ def test_settle_google_sheet(monkeypatch) -> None:
 
     assert result.exit_code == 0
     assert calls == {"url": "https://example.test/sheet.csv", "follow_redirects": True, "timeout": 10}
-    assert "c      -> a          200.00 TWD" in result.stdout
+    _assert_settlement(result.stdout, "c", "a", "200.00 TWD")
 
 
 def test_settle_google_sheet_reports_http_errors(monkeypatch) -> None:
@@ -105,6 +119,7 @@ def test_settle_alias_option(tmp_path: Path) -> None:
     result = runner.invoke(app, ["settle", "--file", str(csv_path), "--alias", "c=a"])
 
     assert result.exit_code == 0
+    assert "Balances" in result.stdout
     assert "No transactions needed." in result.stdout
 
 
@@ -117,7 +132,7 @@ def test_settle_alias_target_can_be_new_member(tmp_path: Path) -> None:
     result = runner.invoke(app, ["settle", "--file", str(csv_path), "--alias", "c=a"])
 
     assert result.exit_code == 0
-    assert "a      -> b           50.00 TWD" in result.stdout
+    _assert_settlement(result.stdout, "a", "b", "50.00 TWD")
 
 
 def test_settle_rejects_invalid_alias(tmp_path: Path) -> None:
@@ -153,4 +168,4 @@ def test_settle_currency_option_is_case_insensitive(tmp_path: Path) -> None:
     result = runner.invoke(app, ["settle", "--file", str(csv_path), "--currency", "usd"])
 
     assert result.exit_code == 0
-    assert "b      -> a           50.00 USD" in result.stdout
+    _assert_settlement(result.stdout, "b", "a", "50.00 USD")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -48,6 +48,19 @@ def test_settle_csv_file(tmp_path: Path) -> None:
     _assert_settlement(result.stdout, "c", "a", "200.00 TWD")
 
 
+def test_settle_balances_use_display_precision_for_status(tmp_path: Path) -> None:
+    csv_path = _write_payments_csv(
+        tmp_path,
+        'amount,payer,members,currency\n0.008,a,"a,b",TWD\n',
+    )
+
+    result = runner.invoke(app, ["settle", "--file", str(csv_path)])
+
+    assert result.exit_code == 0
+    _assert_balance(result.stdout, "a", "+0.00 TWD", "settled")
+    _assert_balance(result.stdout, "b", "+0.00 TWD", "settled")
+
+
 def test_settle_csv_file_uses_sheet_csv_parsing(tmp_path: Path) -> None:
     csv_path = _write_payments_csv(
         tmp_path,

--- a/uv.lock
+++ b/uv.lock
@@ -1205,6 +1205,7 @@ dependencies = [
     { name = "httpx" },
     { name = "pandas" },
     { name = "pydantic" },
+    { name = "rich" },
     { name = "typer" },
 ]
 
@@ -1234,6 +1235,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "pandas", specifier = ">=3.0.1" },
     { name = "pydantic", specifier = ">=2.12.5" },
+    { name = "rich", specifier = ">=15.0.0" },
     { name = "typer", specifier = ">=0.25.1" },
 ]
 


### PR DESCRIPTION
## Summary
- add Rich as a runtime dependency
- render `sharepay settle` balances and settlement transfers as Rich tables
- include balance status labels and update CLI output assertions

## Verification
- `uv run pytest tests`
- `uv run ruff check src/sharepay/cli.py tests/test_cli.py`
- `uv run ty check`
- `uv run prek run -a`
