### PR TITLE
Add max-debtor settlement method

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ live exchange rates, and print the transactions needed to settle up.
 
 - Split group expenses equally across payment members.
 - Calculate who owes whom and produce settlement transactions.
+- Choose default relay settlement or max-debtor settlement, where the largest net debtor coordinates remittances.
 - Import payments from CSV files or public Google Sheets.
 - Convert multi-currency expenses into one settlement currency.
 - Merge duplicate people with aliases such as `johnny=john`.
@@ -72,11 +73,18 @@ sharepay settle --file expenses.csv
 sharepay settle \
   --sheet "https://docs.google.com/spreadsheets/d/<sheet-id>/edit#gid=0"
 sharepay settle --file expenses.csv --currency USD
+sharepay settle --file expenses.csv --settlement-method max-debtor
 sharepay settle --file expenses.csv --alias "johnny=john" --alias "jon=john"
 ```
 
 Supported settlement currencies are `EUR`, `GBP`, `JPY`, `TWD`, `USD`, and `CAD`. The default settlement currency is
 `TWD`.
+
+## Settlement methods
+
+`sharepay settle` uses `--settlement-method relay` by default, preserving the original settlement flow where one member
+may receive money and forward part of it to another member. Use `--settlement-method max-debtor` when the member with the
+largest net debt should send money to every net creditor first; other debtors then reimburse that member.
 
 ## Python API example
 
@@ -102,6 +110,8 @@ for transaction in group.settle_up():
     print(transaction)
 ```
 
+Use `group.settle_up(method="max-debtor")` to choose the max-debtor method from Python.
+
 Output:
 
 ```text
@@ -114,7 +124,8 @@ cara   -> alice      200.00 TWD
 2. The payer is credited for the shares paid on behalf of others.
 3. Expenses in other currencies are converted into the settlement currency with live exchange rates.
 4. Optional aliases canonicalize repeated names before balances are settled.
-5. `settle_up()` returns the transactions needed to bring balances back to zero.
+5. `settle_up()` returns the transactions needed to bring balances back to zero, using relay settlement by default or
+   max-debtor settlement when selected.
 
 ## Development
 

--- a/docs/plans/archived/2026-06-13_max-debtor-settlement-plan.md
+++ b/docs/plans/archived/2026-06-13_max-debtor-settlement-plan.md
@@ -1,0 +1,46 @@
+## Goal
+
+Add a selectable settlement method where the member with the largest net debt is responsible for outgoing remittances, and expose the selection through the `sharepay settle` CLI. Success means the current settlement behavior remains the default, the new max-debtor method can be chosen from Python and CLI, and tests document both methods.
+
+## Context
+
+`ExpenseGroup.settle_up()` previously calculated balances, then created relay-style transactions by making the largest debtor send their full owed amount to the largest creditor. That can require a net creditor to forward money to another creditor. The CLI called `group.settle_up()` without a method option.
+
+## Architecture
+
+Introduced `SettlementMethod` near `ExpenseGroup`, split the relay algorithm from the max-debtor hub algorithm, and kept the CLI thin by parsing the method option and passing it to `ExpenseGroup.settle_up()`.
+
+## Non-Goals
+
+- Do not change CSV or Google Sheet input formats.
+- Do not change currency conversion, alias handling, balance display, or the default settlement behavior unless explicitly requested.
+
+## Assumptions
+
+- "The person who owes the most is responsible for remittance" means: choose the member with the largest positive net balance as a hub; the hub pays all net creditors, then other net debtors reimburse the hub.
+- The CLI option can be named `--settlement-method`, with values `relay` for the current behavior and `max-debtor` for the new behavior.
+
+## Plan
+
+- [x] Add failing tests in `tests/test_expense_group.py` that define the max-debtor method: for balances `a=-100`, `b=-50`, `c=150`, `max-debtor` returns `c -> a 100` and `c -> b 50`; verified with `uv run pytest tests/test_expense_group.py -k max_debtor` (2 passed).
+- [x] Add a multi-debtor test in `tests/test_expense_group.py` where the max debtor pays all creditors and the other debtor reimburses the max debtor; verified transaction order and zeroed applied balances with `uv run pytest tests/test_expense_group.py -k max_debtor` (2 passed).
+- [x] Add a settlement-method enum or literal type in `src/sharepay/expense_group.py` to keep valid methods explicit and preserve `ExpenseGroup.settle_up()` default behavior; verified existing tests still call `settle_up()` without changes using `uv run pytest tests/test_expense_group.py tests/test_cli.py` (21 passed).
+- [x] Refactor the existing `settle_up()` algorithm into a named internal path for the current relay method without behavior changes; verified existing settlement tests still pass with `uv run pytest tests/test_expense_group.py tests/test_cli.py` (21 passed).
+- [x] Implement the max-debtor hub algorithm in `src/sharepay/expense_group.py`: reset/recalculate balances once, select the largest positive balance deterministically, create hub-to-creditor payments for every negative balance, then create other-debtor-to-hub reimbursements; verified with `uv run pytest tests/test_expense_group.py -k max_debtor` (2 passed).
+- [x] Wire a Typer option in `src/sharepay/cli.py` such as `--settlement-method` to pass the chosen method into `group.settle_up()`; verified with `tests/test_cli.py::test_settle_settlement_method_max_debtor` and `uv run pytest tests/test_expense_group.py tests/test_cli.py` (21 passed).
+- [x] Update `README.md` CLI and Python examples to mention the new settlement method and the default method; verified the documented command matches `uv run sharepay settle --help`, which shows `--settlement-method [relay|max-debtor] [default: relay]`.
+- [x] Run quality gates from the repository root; verified with `just lint`, `just type`, `just test`, and `prek run -a`.
+
+## Risks
+
+- The requested business rule could mean a different hub flow than assumed; accepted by making the method behavior explicit in tests and docs.
+- Floating-point residue can create tiny extra transactions; mitigated by reusing the existing `epsilon` threshold for debtor and creditor filtering.
+- Changing `settle_up()` internals could accidentally alter existing transaction order; mitigated by preserving existing tests and adding method-specific tests.
+
+## Completion Checklist
+
+- [x] The current settlement method remains the default, verified by unchanged existing `tests/test_expense_group.py::test_expense_group_settle_up` and `tests/test_cli.py::test_settle_csv_file` results in `just test` (27 passed).
+- [x] The max-debtor settlement method is available from Python, verified by `tests/test_expense_group.py::test_expense_group_settle_up_max_debtor_pays_each_creditor` and `tests/test_expense_group.py::test_expense_group_settle_up_max_debtor_collects_from_other_debtors`.
+- [x] The max-debtor settlement method is available from CLI, verified by `tests/test_cli.py::test_settle_settlement_method_max_debtor`.
+- [x] User-facing docs describe both methods and the CLI option, verified by `README.md` and `uv run sharepay settle --help` output.
+- [x] Repository quality gates pass, verified by `just lint`, `just type`, `just test`, and `prek run -a`.

--- a/src/sharepay/__init__.py
+++ b/src/sharepay/__init__.py
@@ -2,6 +2,7 @@ from .balance import Balance
 from .currency import Currency
 from .debt import Debt
 from .expense_group import ExpenseGroup
+from .expense_group import SettlementMethod
 from .payment import Payment
 from .rate import query_rate
 from .transaction import Transaction

--- a/src/sharepay/cli.py
+++ b/src/sharepay/cli.py
@@ -14,6 +14,7 @@ from .balance import Balance
 from .currency import Currency
 from .expense_group import DEFAULT_CURRENCY
 from .expense_group import ExpenseGroup
+from .expense_group import SettlementMethod
 from .transaction import Transaction
 from .utils import read_payment_csv
 
@@ -138,6 +139,10 @@ def settle(
         list[str] | None,
         typer.Option("--alias", "-a", help="Alias in FROM=TO format. Can be provided multiple times."),
     ] = None,
+    settlement_method: Annotated[
+        SettlementMethod,
+        typer.Option("--settlement-method", case_sensitive=False, help="Settlement method."),
+    ] = SettlementMethod.RELAY,
 ) -> None:
     """Print the transactions needed to settle payments from a CSV file or Google Sheet."""
     if (file is None) == (sheet is None):
@@ -153,7 +158,7 @@ def settle(
         else:
             raise AssertionError("unreachable")
 
-        transactions = group.settle_up()
+        transactions = group.settle_up(method=settlement_method)
     except ValueError as exc:
         raise typer.BadParameter(str(exc)) from exc
     except httpx.HTTPError as exc:

--- a/src/sharepay/expense_group.py
+++ b/src/sharepay/expense_group.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import copy
 import logging
+from enum import StrEnum
 
 import pandas as pd
 from pydantic import BaseModel
@@ -19,6 +20,11 @@ from .utils import read_google_sheet
 logger = logging.getLogger(__name__)
 
 DEFAULT_CURRENCY = Currency.TWD
+
+
+class SettlementMethod(StrEnum):
+    RELAY = "relay"
+    MAX_DEBTOR = "max-debtor"
 
 
 class ExpenseGroup(BaseModel):
@@ -79,12 +85,25 @@ class ExpenseGroup(BaseModel):
             self.balances[creditor].value -= amount
             self.balances[debtor].value += amount
 
-    def settle_up(self, epsilon: float = 1e-6) -> list[Transaction]:
+    def settle_up(
+        self,
+        epsilon: float = 1e-6,
+        method: SettlementMethod | str = SettlementMethod.RELAY,
+    ) -> list[Transaction]:
         self.reset_balance()
         self.calculate_balance()
 
-        transactions = []
         balances = copy.deepcopy(list(self.balances.values()))
+        settlement_method = SettlementMethod(method)
+        if settlement_method is SettlementMethod.RELAY:
+            return self._settle_up_relay(balances, epsilon)
+        if settlement_method is SettlementMethod.MAX_DEBTOR:
+            return self._settle_up_max_debtor(balances, epsilon)
+
+        raise AssertionError("unreachable")
+
+    def _settle_up_relay(self, balances: list[Balance], epsilon: float) -> list[Transaction]:
+        transactions: list[Transaction] = []
         while len(balances) > 1:
             balances = sorted(balances, key=lambda x: x.value)
 
@@ -106,6 +125,40 @@ class ExpenseGroup(BaseModel):
             )
             sender.value -= amount
             recipient.value += amount
+
+        return transactions
+
+    def _settle_up_max_debtor(self, balances: list[Balance], epsilon: float) -> list[Transaction]:
+        creditors = sorted(
+            (balance for balance in balances if balance.value < -epsilon),
+            key=lambda balance: (balance.value, balance.owner),
+        )
+        debtors = sorted(
+            (balance for balance in balances if balance.value > epsilon),
+            key=lambda balance: (-balance.value, balance.owner),
+        )
+        if not creditors or not debtors:
+            return []
+
+        hub = debtors[0]
+        transactions = [
+            Transaction(
+                sender=hub.owner,
+                recipient=creditor.owner,
+                amount=-creditor.value,
+                currency=self.currency,
+            )
+            for creditor in creditors
+        ]
+        transactions.extend(
+            Transaction(
+                sender=debtor.owner,
+                recipient=hub.owner,
+                amount=debtor.value,
+                currency=self.currency,
+            )
+            for debtor in debtors[1:]
+        )
 
         return transactions
 

--- a/src/sharepay/expense_group.py
+++ b/src/sharepay/expense_group.py
@@ -100,7 +100,7 @@ class ExpenseGroup(BaseModel):
         if settlement_method is SettlementMethod.MAX_DEBTOR:
             return self._settle_up_max_debtor(balances, epsilon)
 
-        raise AssertionError("unreachable")
+        raise NotImplementedError(f"Unhandled settlement method: {settlement_method}")
 
     def _settle_up_relay(self, balances: list[Balance], epsilon: float) -> list[Transaction]:
         transactions: list[Transaction] = []

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -182,6 +182,20 @@ def test_settle_rejects_alias_with_multiple_equals(tmp_path: Path) -> None:
     assert "Alias must use FROM=TO format." in result.output
 
 
+def test_settle_settlement_method_max_debtor(tmp_path: Path) -> None:
+    csv_path = _write_payments_csv(
+        tmp_path,
+        'amount,payer,members,currency\n200,a,"a,c",TWD\n100,b,"b,d",TWD\n',
+    )
+
+    result = runner.invoke(app, ["settle", "--file", str(csv_path), "--settlement-method", "max-debtor"])
+
+    assert result.exit_code == 0
+    _assert_settlement(result.stdout, "c", "a", "100.00 TWD")
+    _assert_settlement(result.stdout, "c", "b", "50.00 TWD")
+    _assert_settlement(result.stdout, "d", "c", "50.00 TWD")
+
+
 def test_settle_currency_option_is_case_insensitive(tmp_path: Path) -> None:
     csv_path = _write_payments_csv(
         tmp_path,

--- a/tests/test_expense_group.py
+++ b/tests/test_expense_group.py
@@ -1,5 +1,14 @@
 from sharepay.currency import Currency
 from sharepay.expense_group import ExpenseGroup
+from sharepay.expense_group import SettlementMethod
+
+
+def _apply_transactions(group: ExpenseGroup, transactions):
+    values = {owner: balance.value for owner, balance in group.balances.items()}
+    for transaction in transactions:
+        values[transaction.sender] = values.get(transaction.sender, 0) - transaction.amount
+        values[transaction.recipient] = values.get(transaction.recipient, 0) + transaction.amount
+    return values
 
 
 def test_expense_group_currency() -> None:
@@ -51,6 +60,32 @@ def test_expense_group_settle_up_keeps_each_sender_to_one_transfer() -> None:
         ("c", "a", 150),
         ("a", "b", 50),
     ]
+
+
+def test_expense_group_settle_up_max_debtor_pays_each_creditor() -> None:
+    s = ExpenseGroup(name="test")
+    s.add_payment(amount=200, payer="a", members=["a", "c"], currency=Currency.TWD)
+    s.add_payment(amount=100, payer="b", members=["b", "c"], currency=Currency.TWD)
+    transactions = s.settle_up(method="max-debtor")
+
+    assert [(transaction.sender, transaction.recipient, transaction.amount) for transaction in transactions] == [
+        ("c", "a", 100),
+        ("c", "b", 50),
+    ]
+
+
+def test_expense_group_settle_up_max_debtor_collects_from_other_debtors() -> None:
+    s = ExpenseGroup(name="test")
+    s.add_payment(amount=200, payer="a", members=["a", "c"], currency=Currency.TWD)
+    s.add_payment(amount=100, payer="b", members=["b", "d"], currency=Currency.TWD)
+    transactions = s.settle_up(method=SettlementMethod.MAX_DEBTOR)
+
+    assert [(transaction.sender, transaction.recipient, transaction.amount) for transaction in transactions] == [
+        ("c", "a", 100),
+        ("c", "b", 50),
+        ("d", "c", 50),
+    ]
+    assert all(abs(value) < 1e-6 for value in _apply_transactions(s, transactions).values())
 
 
 def test_expense_group_alias() -> None:


### PR DESCRIPTION
## Summary
- add a SettlementMethod API with relay as the default and max-debtor hub settlement as an option
- expose `--settlement-method` on `sharepay settle`
- document both settlement methods and archive the completed plan

## Verification
- `uv run pytest tests/test_expense_group.py -k max_debtor`
- `uv run pytest tests/test_expense_group.py tests/test_cli.py`
- `just lint`
- `just type`
- `just test`
- `prek run -a`