### PR TITLE
Default to max-debtor settlement

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ live exchange rates, and print the transactions needed to settle up.
 
 - Split group expenses equally across payment members.
 - Calculate who owes whom and produce settlement transactions.
-- Choose default relay settlement or max-debtor settlement, where the largest net debtor coordinates remittances.
+- Use max-debtor settlement by default, where the largest net debtor coordinates remittances.
 - Import payments from CSV files or public Google Sheets.
 - Convert multi-currency expenses into one settlement currency.
 - Merge duplicate people with aliases such as `johnny=john`.
@@ -73,7 +73,7 @@ sharepay settle --file expenses.csv
 sharepay settle \
   --sheet "https://docs.google.com/spreadsheets/d/<sheet-id>/edit#gid=0"
 sharepay settle --file expenses.csv --currency USD
-sharepay settle --file expenses.csv --settlement-method max-debtor
+sharepay settle --file expenses.csv --settlement-method relay
 sharepay settle --file expenses.csv --alias "johnny=john" --alias "jon=john"
 ```
 
@@ -82,9 +82,9 @@ Supported settlement currencies are `EUR`, `GBP`, `JPY`, `TWD`, `USD`, and `CAD`
 
 ## Settlement methods
 
-`sharepay settle` uses `--settlement-method relay` by default, preserving the original settlement flow where one member
-may receive money and forward part of it to another member. Use `--settlement-method max-debtor` when the member with the
-largest net debt should send money to every net creditor first; other debtors then reimburse that member.
+`sharepay settle` uses `--settlement-method max-debtor` by default, where the member with the largest net debt sends
+money to every net creditor first; other debtors then reimburse that member. Use `--settlement-method relay` for the
+original settlement flow where one member may receive money and forward part of it to another member.
 
 ## Python API example
 
@@ -110,7 +110,7 @@ for transaction in group.settle_up():
     print(transaction)
 ```
 
-Use `group.settle_up(method="max-debtor")` to choose the max-debtor method from Python.
+Use `group.settle_up(method="relay")` to choose the relay method from Python.
 
 Output:
 
@@ -124,8 +124,8 @@ cara   -> alice      200.00 TWD
 2. The payer is credited for the shares paid on behalf of others.
 3. Expenses in other currencies are converted into the settlement currency with live exchange rates.
 4. Optional aliases canonicalize repeated names before balances are settled.
-5. `settle_up()` returns the transactions needed to bring balances back to zero, using relay settlement by default or
-   max-debtor settlement when selected.
+5. `settle_up()` returns the transactions needed to bring balances back to zero, using max-debtor settlement by default
+   or relay settlement when selected.
 
 ## Development
 

--- a/src/sharepay/cli.py
+++ b/src/sharepay/cli.py
@@ -142,7 +142,7 @@ def settle(
     settlement_method: Annotated[
         SettlementMethod,
         typer.Option("--settlement-method", case_sensitive=False, help="Settlement method."),
-    ] = SettlementMethod.RELAY,
+    ] = SettlementMethod.MAX_DEBTOR,
 ) -> None:
     """Print the transactions needed to settle payments from a CSV file or Google Sheet."""
     if (file is None) == (sheet is None):

--- a/src/sharepay/expense_group.py
+++ b/src/sharepay/expense_group.py
@@ -88,7 +88,7 @@ class ExpenseGroup(BaseModel):
     def settle_up(
         self,
         epsilon: float = 1e-6,
-        method: SettlementMethod | str = SettlementMethod.RELAY,
+        method: SettlementMethod | str = SettlementMethod.MAX_DEBTOR,
     ) -> list[Transaction]:
         self.reset_balance()
         self.calculate_balance()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -182,18 +182,30 @@ def test_settle_rejects_alias_with_multiple_equals(tmp_path: Path) -> None:
     assert "Alias must use FROM=TO format." in result.output
 
 
-def test_settle_settlement_method_max_debtor(tmp_path: Path) -> None:
+def test_settle_defaults_to_max_debtor(tmp_path: Path) -> None:
     csv_path = _write_payments_csv(
         tmp_path,
-        'amount,payer,members,currency\n200,a,"a,c",TWD\n100,b,"b,d",TWD\n',
+        'amount,payer,members,currency\n200,a,"a,c",TWD\n100,b,"b,c",TWD\n',
     )
 
-    result = runner.invoke(app, ["settle", "--file", str(csv_path), "--settlement-method", "max-debtor"])
+    result = runner.invoke(app, ["settle", "--file", str(csv_path)])
 
     assert result.exit_code == 0
     _assert_settlement(result.stdout, "c", "a", "100.00 TWD")
     _assert_settlement(result.stdout, "c", "b", "50.00 TWD")
-    _assert_settlement(result.stdout, "d", "c", "50.00 TWD")
+
+
+def test_settle_settlement_method_relay(tmp_path: Path) -> None:
+    csv_path = _write_payments_csv(
+        tmp_path,
+        'amount,payer,members,currency\n200,a,"a,c",TWD\n100,b,"b,c",TWD\n',
+    )
+
+    result = runner.invoke(app, ["settle", "--file", str(csv_path), "--settlement-method", "relay"])
+
+    assert result.exit_code == 0
+    _assert_settlement(result.stdout, "c", "a", "150.00 TWD")
+    _assert_settlement(result.stdout, "a", "b", "50.00 TWD")
 
 
 def test_settle_currency_option_is_case_insensitive(tmp_path: Path) -> None:

--- a/tests/test_expense_group.py
+++ b/tests/test_expense_group.py
@@ -48,11 +48,23 @@ def test_expense_group_settle_up() -> None:
     assert transactions[0].amount == 200
 
 
-def test_expense_group_settle_up_keeps_each_sender_to_one_transfer() -> None:
+def test_expense_group_settle_up_defaults_to_max_debtor() -> None:
     s = ExpenseGroup(name="test")
     s.add_payment(amount=200, payer="a", members=["a", "c"], currency=Currency.TWD)
     s.add_payment(amount=100, payer="b", members=["b", "c"], currency=Currency.TWD)
     transactions = s.settle_up()
+
+    assert [(transaction.sender, transaction.recipient, transaction.amount) for transaction in transactions] == [
+        ("c", "a", 100),
+        ("c", "b", 50),
+    ]
+
+
+def test_expense_group_settle_up_relay_keeps_each_sender_to_one_transfer() -> None:
+    s = ExpenseGroup(name="test")
+    s.add_payment(amount=200, payer="a", members=["a", "c"], currency=Currency.TWD)
+    s.add_payment(amount=100, payer="b", members=["b", "c"], currency=Currency.TWD)
+    transactions = s.settle_up(method=SettlementMethod.RELAY)
 
     senders = [transaction.sender for transaction in transactions]
     assert len(senders) == len(set(senders))


### PR DESCRIPTION
## Summary
- change Python and CLI settlement defaults to `max-debtor`
- keep relay available through explicit method/CLI option
- update docs and tests for the new default

## Verification
- `uv run pytest tests/test_expense_group.py tests/test_cli.py`
- `uv run sharepay settle --help`
- `just lint && just type && just test`
- `prek run -a`